### PR TITLE
Add styling for authentication links section

### DIFF
--- a/CSS/styles.css
+++ b/CSS/styles.css
@@ -368,6 +368,11 @@ textarea:focus {
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
 }
 
+.auth-links {
+  text-align: center;
+  margin-top: 1.5rem;
+}
+
 .hero {
   background: url("hero.jpg") no-repeat center center/cover;
   height: 500px;


### PR DESCRIPTION
Create a centered layout for authentication-related links (e.g., signup, forgot password) by adding spacing above the section for better visual separation from the form.