### PR TITLE
Enhance rent container and back-lick icon spacing

### DIFF
--- a/CSS/styles.css
+++ b/CSS/styles.css
@@ -749,6 +749,17 @@ textarea:focus {
   margin-bottom: 2rem;
   color: var(--primary-color);
 }
+.back-link i {
+  margin-right: 0.5rem;
+}
+
+.rent-container {
+  background-color: #fff;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  border: 1px solid var(--border-color);
+  padding: 1.5rem;
+}
 
 .hero {
   background: url("hero.jpg") no-repeat center center/cover;


### PR DESCRIPTION
Improve the rent page container by adding background, border, padding, and shadow. Also, add spacing between the icon and text inside the back link.