### PR TITLE
Align rent header items with flexbox and add margin

### DIFF
--- a/CSS/styles.css
+++ b/CSS/styles.css
@@ -761,6 +761,12 @@ textarea:focus {
   padding: 1.5rem;
 }
 
+.rent-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
 .hero {
   background: url("hero.jpg") no-repeat center center/cover;
   height: 500px;


### PR DESCRIPTION
Align items horizontally in the rent header section using flexbox and add margin at the bottom for spacing.