### PR TITLE
Add width and margin to rent service image

### DIFF
--- a/CSS/styles.css
+++ b/CSS/styles.css
@@ -767,6 +767,11 @@ textarea:focus {
   margin-bottom: 1.5rem;
 }
 
+.rent-service-image {
+  width: 120px;
+  margin-right: 1.5rem;
+}
+
 .hero {
   background: url("hero.jpg") no-repeat center center/cover;
   height: 500px;


### PR DESCRIPTION
Style the service image inside the rent section by setting a fixed width and right margin for better layout alignment.